### PR TITLE
Change: Use trusted publisher upload for PyPI

### DIFF
--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -6,5 +6,8 @@ on:
 
 jobs:
   deploy:
+    permissions:
+      id-token: write
     uses: greenbone/workflows/.github/workflows/deploy-pypi.yml@main
-    secrets: inherit
+    with:
+      pypi-url: https://pypi.org/project/autohooks-plugin-ruff/


### PR DESCRIPTION
## What

Use trusted publisher upload for PyPI

## Why
[Trusted publisher](https://docs.pypi.org/trusted-publishers/) improves the security of the deployment

## References

DEVOPS-941