### PR TITLE
Fix: fix deprecated ruff command

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -20,7 +20,7 @@ jobs:
     with:
       lint-packages: autohooks tests
       python-version: ${{ matrix.python-version }}
-      linter: ruff
+      linter: ruff check
 
   test:
     strategy:


### PR DESCRIPTION
## What

Fix deprecated "ruff" command in favor of "ruff check"

## Why

Fix deprecated "ruff" command 

## References

[DEVOPS-1093](https://jira.greenbone.net/browse/DEVOPS-1093)

