### PR TITLE
Fixed typo in repo URL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 ]
 readme = "README.md"
 homepage = "https://github.com/greenbone/autohooks-plugin-ruff"
-repository = "https://github.com/greeenbone/autohooks-plugin-ruff"
+repository = "https://github.com/greenbone/autohooks-plugin-ruff"
 # Full list: https://pypi.org/pypi?%3Aaction=list_classifiers
 classifiers = [
   "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
## What

Fixes a typo in the repo URL in `pyproject.toml` ("greeenbone").

## Why

The typo is causing Dependabot to put an invalid URL in its PR descriptions when proposing updates to this library in other repositories.

Example: https://github.com/todofixthis/filters-pydantic/pull/27

![Captura de pantalla 2025-03-12 a las 6 57 55](https://github.com/user-attachments/assets/82f52c45-e1af-49fa-b80d-d3ed5177e258)

![Captura de pantalla 2025-03-12 a las 6 58 02](https://github.com/user-attachments/assets/0a91ac79-9f8b-435b-a429-1a14009e2d2c)